### PR TITLE
fix: resolve core imports in database modules

### DIFF
--- a/src/databases/graph/relationships.py
+++ b/src/databases/graph/relationships.py
@@ -12,10 +12,10 @@ from datetime import datetime
 import json
 from contextlib import asynccontextmanager
 
-from ..core.base import (
+from ...core.base import (
     BaseDatabase, GraphOperations, DatabaseType, QueryResult, EntityMetadata
 )
-from ..core.config import DatabaseConfig
+from ...core.config import DatabaseConfig
 from ..utils.logging import get_logger, monitor_performance, CircuitBreaker
 
 logger = get_logger("graph_db")

--- a/src/databases/postgresql/crud.py
+++ b/src/databases/postgresql/crud.py
@@ -12,10 +12,10 @@ from datetime import datetime
 import json
 from contextlib import asynccontextmanager
 
-from ..core.base import (
+from ...core.base import (
     BaseDatabase, CRUDOperations, DatabaseType, QueryResult, EntityMetadata
 )
-from ..core.config import DatabaseConfig
+from ...core.config import DatabaseConfig
 from ..utils.logging import get_logger, monitor_performance, CircuitBreaker
 
 logger = get_logger("postgresql")

--- a/src/databases/vector/embeddings.py
+++ b/src/databases/vector/embeddings.py
@@ -14,10 +14,10 @@ import json
 from sentence_transformers import SentenceTransformer
 from contextlib import asynccontextmanager
 
-from ..core.base import (
+from ...core.base import (
     BaseDatabase, VectorOperations, DatabaseType, QueryResult, EntityMetadata
 )
-from ..core.config import DatabaseConfig
+from ...core.config import DatabaseConfig
 from ..utils.logging import get_logger, monitor_performance, CircuitBreaker
 
 logger = get_logger("vector_db")


### PR DESCRIPTION
## Summary
- fix relative imports to reference root `core` package in PostgreSQL, vector, and graph database modules

## Testing
- `python -m py_compile src/databases/postgresql/crud.py src/databases/vector/embeddings.py src/databases/graph/relationships.py`


------
https://chatgpt.com/codex/tasks/task_b_68a1137cf1008324a31851fdb7755b5f