### PR TITLE
Implement unified query orchestration helpers

### DIFF
--- a/src/core/base.py
+++ b/src/core/base.py
@@ -8,7 +8,7 @@ and Apache AGE graph databases.
 
 from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Optional, Union, AsyncGenerator, Tuple
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, asdict
 from datetime import datetime
 from enum import Enum
 import asyncio
@@ -387,24 +387,96 @@ class UnifiedDatabase:
         """Get a specific database instance."""
         return self.databases.get(db_type)
     
-    async def execute_unified_query(self, 
+    async def execute_unified_query(self,
                                    query_type: str,
                                    entity_data: Dict[str, Any],
                                    target_databases: Optional[List[DatabaseType]] = None) -> Dict[DatabaseType, QueryResult]:
-        """
-        Execute a query across multiple databases with automatic synchronization.
+        """Execute a query against one or more databases.
+
+        This method provides a thin orchestration layer that dispatches
+        operations to the appropriate database handler based on ``query_type``.
+        The ``entity_data`` dictionary is passed as keyword arguments to the
+        handler method. Results from each database are aggregated into a single
+        dictionary keyed by :class:`DatabaseType`.
+
+        Parameters
+        ----------
+        query_type:
+            Name of the handler method to execute (e.g. ``"create"`` or
+            ``"execute_query"``).
+        entity_data:
+            Parameters to forward to the handler method.
+        target_databases:
+            Optional list of databases to target.  When ``None`` all registered
+            databases are used.
+
+        Returns
+        -------
+        Dict[DatabaseType, QueryResult]
+            Mapping of database type to the resulting :class:`QueryResult`.
         """
         if target_databases is None:
             target_databases = list(self.databases.keys())
-        
-        results = {}
-        
+
+        results: Dict[DatabaseType, QueryResult] = {}
+
+        entity_id = entity_data.get("entity_id")
+        entity_type = entity_data.get("entity_type", "unknown")
+        metadata: Optional[EntityMetadata] = None
+
+        if entity_id and self.metadata_manager:
+            try:
+                metadata = await self.metadata_manager.get_metadata(entity_id)
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.error(f"Metadata lookup failed: {exc}")
+
+            if metadata is None:
+                metadata = EntityMetadata(entity_id=entity_id, entity_type=entity_type)
+
         for db_type in target_databases:
-            db = self.databases[db_type]
-            # Execute query based on database type and capabilities
-            # This will be implemented in specific subclasses
-            pass
-        
+            db = self.databases.get(db_type)
+            if not db:
+                continue
+
+            try:
+                handler = getattr(db, query_type, None)
+                if not callable(handler):
+                    raise AttributeError(f"{db_type.value} database has no '{query_type}' method")
+
+                result = await handler(**entity_data)
+
+                if not isinstance(result, QueryResult):
+                    result = QueryResult(success=True, data=result, source_database=db_type)
+
+                results[db_type] = result
+
+                if metadata and result.success:
+                    setattr(metadata, f"in_{db_type.value}", True)
+                    metadata.mark_synced(db_type)
+                elif metadata and not result.success:
+                    metadata.sync_errors.append(result.error or f"{db_type.value} {query_type} failed")
+
+            except Exception as exc:
+                logger.error(f"{db_type.value} {query_type} failed: {exc}")
+                results[db_type] = QueryResult(
+                    success=False,
+                    data=None,
+                    error=str(exc),
+                    source_database=db_type,
+                )
+                if metadata:
+                    metadata.sync_errors.append(str(exc))
+
+        if metadata and self.metadata_manager:
+            try:
+                existing = await self.metadata_manager.get_metadata(metadata.entity_id)
+                if existing:
+                    await self.metadata_manager.update_metadata(metadata.entity_id, asdict(metadata))
+                else:
+                    await self.metadata_manager.store_metadata(metadata)
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.error(f"Failed to update metadata for {metadata.entity_id}: {exc}")
+
         return results
     
     async def get_unified_metrics(self) -> Dict[str, Any]:
@@ -420,20 +492,157 @@ async def create_unified_entity(unified_db: UnifiedDatabase,
                                entity_type: str,
                                entity_data: Dict[str, Any],
                                sync_mode: SyncMode = SyncMode.HYBRID) -> str:
+    """Create an entity across all databases and record metadata.
+
+    The function generates an ``entity_id`` if one is not provided and then
+    performs the appropriate create/insert operation on each database handled by
+    ``unified_db``.  Metadata is updated to reflect which databases contain the
+    entity.  Basic error handling ensures that failures in one database do not
+    prevent attempts on others.
+
+    Parameters
+    ----------
+    unified_db:
+        Instance of :class:`UnifiedDatabase` coordinating the databases.
+    entity_type:
+        Logical type of the entity being created (e.g. ``"user"``).
+    entity_data:
+        Data describing the entity.  The dictionary is forwarded to the
+        underlying database implementations.
+    sync_mode:
+        Determines whether the operation should target all databases immediately
+        or defer to eventual consistency.  ``SyncMode.EVENTUAL`` only stores the
+        entity in PostgreSQL and records metadata for later synchronization.
+
+    Returns
+    -------
+    str
+        The identifier for the created entity.
     """
-    Create an entity across all relevant databases with proper synchronization.
-    """
-    # This will be implemented as part of the unified operations
-    pass
+    entity_id = entity_data.get("entity_id") or f"{entity_type}_{int(datetime.utcnow().timestamp() * 1000)}"
+    entity_data["entity_id"] = entity_id
+    entity_data.setdefault("entity_type", entity_type)
+
+    metadata = EntityMetadata(entity_id=entity_id, entity_type=entity_type)
+
+    # Always create in PostgreSQL as the source of truth
+    try:
+        pg_result = await unified_db.postgresql.create(f"{entity_type}s", entity_data)
+        if pg_result.success:
+            metadata.in_postgresql = True
+            metadata.mark_synced(DatabaseType.POSTGRESQL)
+        else:
+            metadata.sync_errors.append(pg_result.error or "postgresql create failed")
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.error(f"PostgreSQL create failed: {exc}")
+        metadata.sync_errors.append(str(exc))
+
+    # If immediate sync is requested, attempt to store in vector and graph DBs
+    if sync_mode != SyncMode.EVENTUAL:
+        # Vector database – insert text embedding if provided
+        try:
+            if hasattr(unified_db.vector, "insert_text_embedding") and (
+                entity_data.get("text_content") or entity_data.get("embedding")
+            ):
+                text = entity_data.get("text_content")
+                if text is not None:
+                    v_result = await unified_db.vector.insert_text_embedding(entity_id, text, {"entity_type": entity_type})
+                else:
+                    v_result = await unified_db.vector.insert_embedding(entity_id, entity_data["embedding"], {"entity_type": entity_type})
+                if v_result.success:
+                    metadata.in_vector = True
+                    metadata.mark_synced(DatabaseType.VECTOR)
+                else:
+                    metadata.sync_errors.append(v_result.error or "vector insert failed")
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.error(f"Vector insert failed: {exc}")
+            metadata.sync_errors.append(str(exc))
+
+        # Graph database – create node
+        try:
+            if hasattr(unified_db.graph, "create_node"):
+                node_props = dict(entity_data)
+                g_result = await unified_db.graph.create_node(entity_type, node_props)
+                if g_result.success:
+                    metadata.in_graph = True
+                    metadata.mark_synced(DatabaseType.GRAPH)
+                else:
+                    metadata.sync_errors.append(g_result.error or "graph create failed")
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.error(f"Graph create failed: {exc}")
+            metadata.sync_errors.append(str(exc))
+
+    # Store metadata
+    if unified_db.metadata_manager:
+        try:
+            await unified_db.metadata_manager.store_metadata(metadata)
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.error(f"Failed to store metadata for {entity_id}: {exc}")
+
+    return entity_id
 
 
 async def query_across_databases(unified_db: UnifiedDatabase,
                                 query_spec: Dict[str, Any]) -> Dict[str, QueryResult]:
+    """Execute queries on multiple databases and aggregate the results.
+
+    The ``query_spec`` dictionary describes which method to call on each
+    database and the parameters to use.  Keys can be either
+    :class:`DatabaseType` members or their string representations.  Each value
+    must at least contain a ``"method"`` entry specifying the handler name.
+
+    Example
+    -------
+    >>> await query_across_databases(db, {
+    ...     DatabaseType.POSTGRESQL: {"method": "execute_query", "query": "SELECT 1"},
+    ...     "vector": {"method": "similarity_search", "query_embedding": [0.1, 0.2], "limit": 5}
+    ... })
+
+    Parameters
+    ----------
+    unified_db:
+        The :class:`UnifiedDatabase` instance.
+    query_spec:
+        Specification of database operations to execute.
+
+    Returns
+    -------
+    Dict[str, QueryResult]
+        Mapping of database name to :class:`QueryResult` objects.
     """
-    Execute federated queries across multiple database types.
-    """
-    # This will be implemented as part of the query coordination system
-    pass
+    results: Dict[str, QueryResult] = {}
+
+    for db_key, spec in query_spec.items():
+        try:
+            db_type = db_key if isinstance(db_key, DatabaseType) else DatabaseType(db_key)
+        except Exception:
+            logger.error(f"Invalid database type: {db_key}")
+            continue
+
+        db = await unified_db.get_database(db_type)
+        if db is None:
+            logger.error(f"Database handler not available for {db_type.value}")
+            continue
+
+        method_name = spec.get("method", "execute_query")
+        params = {k: v for k, v in spec.items() if k != "method"}
+
+        try:
+            method = getattr(db, method_name)
+            result = await method(**params)
+            if not isinstance(result, QueryResult):
+                result = QueryResult(success=True, data=result, source_database=db_type)
+            results[db_type.value] = result
+        except Exception as exc:
+            logger.error(f"Query on {db_type.value} failed: {exc}")
+            results[db_type.value] = QueryResult(
+                success=False,
+                data=None,
+                error=str(exc),
+                source_database=db_type,
+            )
+
+    return results
 
 
 # Example usage and testing


### PR DESCRIPTION
## Summary
- Add `execute_unified_query` to coordinate database operations and update metadata
- Implement `create_unified_entity` for cross-database entity creation with sync tracking
- Introduce `query_across_databases` to run federated operations across different databases

## Testing
- `PYTHONPATH=src pytest tests/test_3db_core.py::TestDatabase3D::test_initialization -q` *(fails: ImportError: attempted relative import with no known parent package)*

------
https://chatgpt.com/codex/tasks/task_b_68a113813d28832497378ecb94e5303c