### PR TITLE
Add to_dict helper to EntityMetadata and streamline metadata usage

### DIFF
--- a/src/core/base.py
+++ b/src/core/base.py
@@ -8,7 +8,7 @@ and Apache AGE graph databases.
 
 from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Optional, Union, AsyncGenerator, Tuple
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, asdict
 from datetime import datetime
 from enum import Enum
 import asyncio
@@ -64,6 +64,10 @@ class EntityMetadata:
     def clear_sync_errors(self) -> None:
         """Clear all synchronization errors."""
         self.sync_errors.clear()
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return metadata as a dictionary."""
+        return asdict(self)
 
 
 @dataclass

--- a/src/unified.py
+++ b/src/unified.py
@@ -388,7 +388,7 @@ class Database3D:
                 'entity_id': entity_id,
                 'success': success,
                 'results': results,
-                'metadata': metadata.to_dict() if hasattr(metadata, 'to_dict') else str(metadata)
+                'metadata': metadata.to_dict()
             }
             
         except Exception as e:


### PR DESCRIPTION
## Summary
- add `to_dict` method to `EntityMetadata` for easy serialization
- drop `hasattr` check and rely on `to_dict` in unified entity creation

## Testing
- `pytest` *(fails: ImportError: attempted relative import with no known parent package)*

------
https://chatgpt.com/codex/tasks/task_b_68a1138623888324adf5647af5a34590