### PR TITLE
refactor: ensure tests import from src package

### DIFF
--- a/tests/test_3db_core.py
+++ b/tests/test_3db_core.py
@@ -169,7 +169,7 @@ class TestEntityManagement:
         db3d = mock_3db_system
         
         # Mock PostgreSQL failure
-        from core.base import QueryResult
+        from src.core.base import QueryResult
         db3d.postgresql_db.create.return_value = QueryResult(
             success=False,
             data=None,


### PR DESCRIPTION
## Summary
- adjust test path setup to add project root instead of src
- use `src.` package prefix for all project imports in tests
- add lightweight stubs and async fixtures for dependency-free testing

## Testing
- `pytest -q` *(fails: assert False is True)*

------
https://chatgpt.com/codex/tasks/task_b_68a11ff23ce48324ac529a0eea7d7c39